### PR TITLE
fix(library): apply HTML attrs to all list elements

### DIFF
--- a/.changeset/dry-cars-camp.md
+++ b/.changeset/dry-cars-camp.md
@@ -1,0 +1,45 @@
+---
+"astro-toc": minor
+---
+
+**Feat:** Apply HTML attributes (e.g. `class`, `data-*`) to root and nested list elements.
+
+```jsx
+---
+const toc = [
+  { depth: 1, title: "Level 1, Item 1" },
+  { depth: 2, title: "Level 2, Item 1" },
+  { depth: 2, title: "Level 2, Item 2" },
+  { depth: 3, title: "Level 3, Item 1" },
+  { depth: 1, title: "Level 1, Item 2" },
+];
+---
+
+<TOC toc={toc} class="toc-container" />
+
+<style>
+  .toc-container {
+    padding: 1rem;
+  }
+</style>
+```
+
+HTML Output:
+
+```html
+<ul data-astro-toc="1" class="toc-container" data-astro-cid-j7pv25f6="true">
+  <li data-astro-toc="1">
+    Level 1, Item 1
+    <ul data-astro-toc="2" class="toc-container" data-astro-cid-j7pv25f6="true">
+      <li data-astro-toc="2">Level 2, Item 1</li>
+      <li data-astro-toc="2">
+        Level 2, Item 2
+        <ul data-astro-toc="3" class="toc-container" data-astro-cid-j7pv25f6="true">
+          <li data-astro-toc="3">Level 3, Item 1</li>
+        </ul>
+      </li>
+    </ul>
+  </li>
+  <li data-astro-toc="1">Level 1, Item 2</li>
+</ul>
+```

--- a/.changeset/perfect-dots-switch.md
+++ b/.changeset/perfect-dots-switch.md
@@ -2,21 +2,6 @@
 "astro-toc": minor
 ---
 
-## **astro-toc**
-
-**Feat:** Apply passed in scoped styles
-
-```jsx
-<style>
-  .text-large {
-    font-size: 3rem;
-  }
-</style>
-<TOC toc={toc} class="text-large" />
-```
-
----
-
 **Feat:** Use `depth` prop to set initial depth
 
 ```jsx

--- a/packages/astro-toc/lib/TOC.astro
+++ b/packages/astro-toc/lib/TOC.astro
@@ -9,7 +9,7 @@ const headings = toc.filter((it) => it.depth === depth);
 const Tag = "bullet" === as ? "ul" : "number" === as ? "ol" : "menu";
 ---
 
-<Tag data-astro-toc={depth} {...depth === 1 ? attrs : {}}>
+<Tag data-astro-toc={depth} {...attrs}>
   {
     headings.map((it, idx) => {
       const nextHeading = headings[idx + 1];


### PR DESCRIPTION
This PR fixes an error in PR #10 in regard to applying HTML attributes.

It ensures that attributes (like `class`, `data-*`) passed to the `<TOC />` component are correctly applied recursively to nested list elements (`ul`, `ol`, `menu`), not just the root container.

The associated changeset has been updated and a new changeset added to reflect the corrected behavior.

Related to #10