### PR TITLE
chore: add CodeSandbox config for demo and update READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,4 @@ npm install astro-toc
 [Documentation](packages/astro-toc/README.md)
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/theisel/astro-toc/tree/main/demo)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/github/theisel/astro-toc/tree/main/demo)

--- a/demo/.codesandbox/tasks.json
+++ b/demo/.codesandbox/tasks.json
@@ -1,0 +1,8 @@
+{
+  "setupTasks": [
+    {
+      "name": "Install Dependencies",
+      "command": "pnpm install astro@latest astro-toc@latest && pnpm start"
+    }
+  ]
+}

--- a/demo/.devcontainer/devcontainer.json
+++ b/demo/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "name": "astro-toc demo",
+  "image": "ghcr.io/codesandbox/devcontainers/typescript-node:latest",
+  "postCreateCommand": "npm install --global pnpm@latest"
+}

--- a/packages/astro-toc/README.md
+++ b/packages/astro-toc/README.md
@@ -36,9 +36,10 @@ A flexible Table of Contents (ToC) generator for [Astro](https://astro.build/). 
 
 ## Demo
 
-Try it out live on:
+Try it out on:
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/theisel/astro-toc/tree/main/demo)
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/theisel/astro-toc/tree/main/demo) 
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/github/theisel/astro-toc/tree/main/demo)
 
 ## Installation
 


### PR DESCRIPTION
This PR adds configuration for `CodeSandbox` to ensure the `demo` package runs correctly when launched and updates READMEs with the corresponding link.

## Key Changes

* Adds configuration and setup task files within the `demo` directory to ensure it runs correctly in the CodeSandbox environment.
* Updates both the root and library README files to include "Open in CodeSandbox" links pointing to the demo package.