### PR TITLE
docs(root): improve README structure and content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,47 @@
-<div>
+<div align="center">
   <img src="https://raw.githubusercontent.com/theisel/astro-toc/main/logo.svg" width="240" alt="astro-toc logo">
 </div>
+<h1 align="center">astro-toc</h1>
 
-# astro-toc
+<div align="center">
 
-![license](https://img.shields.io/npm/l/astro-toc?style=flat-square)
-[![build](https://img.shields.io/github/actions/workflow/status/theisel/astro-toc/ci.yml?style=flat-square)](https://github.com/theisel/astro-toc/actions)
 [![npm](https://img.shields.io/npm/v/astro-toc?style=flat-square)](https://www.npmjs.com/package/astro-toc)
+[![build](https://img.shields.io/github/actions/workflow/status/theisel/astro-toc/ci.yml?style=flat-square&branch=main)](https://github.com/theisel/astro-toc/actions/workflows/ci.yml)
+![license](https://img.shields.io/npm/l/astro-toc?style=flat-square)
 
-Table of Contents (ToC) generator for [Astro](https://astro.build).
+A flexible and customizable Table of Contents (ToC) generator component for [Astro](https://astro.build/). Automatically builds nested navigation from your data, perfect for blogs, documentation, and content-rich sites.
 
-```
-npm install astro-toc
-```
+</div>
 
-[Documentation](packages/astro-toc/README.md)
+&nbsp;
+
+## ✨ Features
+
+* Generates semantic, nested lists (`ul`, `ol`, `menu`).
+* Supports custom Astro components for rendering items via the `use` prop.
+* Control over minimum (`depth`) and maximum (`maxDepth`) levels shown.
+* Accepts standard HTML attributes (`class`, `data-*`, etc.) for styling the container.
+* Fully typed with TypeScript.
+
+&nbsp;
+
+## 📦 Package Documentation
+
+`astro-toc` usage instructions, examples, and the full API reference can be found in its dedicated README:
+
+[**View Package README &rarr;**](./packages/astro-toc/README.md)
+
+&nbsp;
+
+## 🚀 Demo
+
+Give `astro-toc` a try on:
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/theisel/astro-toc/tree/main/demo)
 [![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/github/theisel/astro-toc/tree/main/demo)
+
+&nbsp;
+
+## 📄 License
+
+Licensed under the ISC License.


### PR DESCRIPTION
This PR improves the root README to provide a better high-level overview of the `astro-toc` project.

## Key Changes

* Restructures the layout for better readability.
* Improves the introductory description.
* Adds "Features", "Package Documentation", and "Demo" sections.
* Removes installation instructions (deferred to package README).