### PR TITLE
ci(release): fix `id-token` permission error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+  id-token: write
+
 env:
   NPM_CONFIG_PROVENANCE: true
 


### PR DESCRIPTION
This PR fixes `id-token` permission error by adding `id-token: write` permission to the `Release` workflow