### PR TITLE
ci(release): upgrade `contents` permission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
         type: string
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 env:


### PR DESCRIPTION
This PR upgrades the previous `contents` permission from `read` to `write`.